### PR TITLE
First version with MELA weights, all STXS (modified for VBF ac) and PDF weights

### DIFF
--- a/Systematics/test/runAnomCouplings/runBackground.sh
+++ b/Systematics/test/runAnomCouplings/runBackground.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_07102022"
+storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_2023_01_27_allSTXSCats"
 outDir=$1
 if [[ -z $outDir ]]; then
     echo "usage: $0 <outDir>"
@@ -13,16 +13,16 @@ year2018Dir="background_IA_UL18"
 
 
 mkdir -p ${storageDir}/${outDir}_${year2016preVFPDir}
-fggRunJobs.py --load bkg_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 100 -H --no-copy-proxy &
+fggRunJobs.py --load bkg_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=False anomalousCouplings=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 100 -H --no-copy-proxy &
 
 mkdir -p ${storageDir}/${outDir}_${year2016postVFPDir}
-fggRunJobs.py --load bkg_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 100 -H --no-copy-proxy &
+fggRunJobs.py --load bkg_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=False anomalousCouplings=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 100 -H --no-copy-proxy &
 
-#mkdir -p ${storageDir}/${outDir}_${year2017Dir}
-#fggRunJobs.py --load bkg_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 100 -H --no-copy-proxy &
+mkdir -p ${storageDir}/${outDir}_${year2017Dir}
+fggRunJobs.py --load bkg_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=False anomalousCouplings=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 100 -H --no-copy-proxy &
 
 mkdir -p ${storageDir}/${outDir}_${year2018Dir}
-fggRunJobs.py --load bkg_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 100 -H --no-copy-proxy &
+fggRunJobs.py --load bkg_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=False dumpTrees=True doSystematics=False applyNNLOPSweight=False doPdfWeights=False recalculatePDFWeights=False vbfTagsOnly=False anomalousCouplings=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 100 -H --no-copy-proxy &
 
 
 

--- a/Systematics/test/runAnomCouplings/runData.sh
+++ b/Systematics/test/runAnomCouplings/runData.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_07102022"
+storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_2023_01_27_allSTXSCats"
 outDir=$1
 if [[ -z $outDir ]]; then
     echo "usage: $0 <outDir>"
@@ -12,13 +12,13 @@ year2017Dir="data_IA_UL17"
 year2018Dir="data_IA_UL18"
 
 mkdir -p ${storageDir}/${outDir}_${year2016preVFPDir}
-fggRunJobs.py --load data_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 500 -H --no-copy-proxy &
+fggRunJobs.py --load data_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False anomalousCouplings=True  melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 500 -H --no-copy-proxy &
 
 mkdir -p ${storageDir}/${outDir}_${year2016postVFPDir}
-fggRunJobs.py --load data_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 500 -H --no-copy-proxy &
+fggRunJobs.py --load data_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False anomalousCouplings=True  melaEFT=False --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 500 -H --no-copy-proxy &
 
 mkdir -p ${storageDir}/${outDir}_${year2017Dir}
-fggRunJobs.py --load data_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 500 -H --no-copy-proxy &
+fggRunJobs.py --load data_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False anomalousCouplings=True  melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 500 -H --no-copy-proxy &
 
 mkdir -p ${storageDir}/${outDir}_${year2018Dir}
-fggRunJobs.py --load data_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 500 -H --no-copy-proxy &
+fggRunJobs.py --load data_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=True doSystematics=False applyNNLOPSweight=False recalculatePDFWeights=False anomalousCouplings=True  melaEFT=False  --nCondorCpu=2 --no-use-tarball pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 500 -H --no-copy-proxy &

--- a/Systematics/test/runAnomCouplings/runSignal.sh
+++ b/Systematics/test/runAnomCouplings/runSignal.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_07102022"
+storageDir="/eos/cms/store/group/dpg_ecal/comm_ecal/localreco/vbfhgg/HiggsCouplings/Trees_2023_01_27_allSTXSCats"
 outDir=$1
 if [[ -z $outDir ]]; then
     echo "usage: $0 <outDir>"
@@ -12,13 +12,13 @@ year2017Dir="signal_IA_UL17"
 year2018Dir="signal_IA_UL18"
 
 mkdir -p ${storageDir}/${outDir}_${year2016preVFPDir}
-fggRunJobs.py --load sig_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=False doPdfWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
+fggRunJobs.py --load sig_jobs_2016preVFP_UL.json -d ${outDir}_${year2016preVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=True doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=True doPdfWeights=True useParentDataset=True anomalousCouplings=True dumpLHE=False melaEFT=True --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016preVFPDir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
 
 mkdir -p ${storageDir}/${outDir}_${year2016postVFPDir}
-fggRunJobs.py --load sig_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=False doPdfWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
+fggRunJobs.py --load sig_jobs_2016postVFP_UL.json -d ${outDir}_${year2016postVFPDir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=False doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=True doPdfWeights=True useParentDataset=True anomalousCouplings=True dumpLHE=False melaEFT=True --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2016postVFPDir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
 
 mkdir -p ${storageDir}/${outDir}_${year2017Dir}
-fggRunJobs.py --load sig_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=False doPdfWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
+fggRunJobs.py --load sig_jobs_2017_UL.json -d ${outDir}_${year2017Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=False doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=True doPdfWeights=True useParentDataset=True anomalousCouplings=True dumpLHE=False melaEFT=True --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2017Dir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
 
 mkdir -p ${storageDir}/${outDir}_${year2018Dir}
-fggRunJobs.py --load sig_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpWorkspace=True dumpTrees=True doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=False doPdfWeights=False vbfTagsOnly=True dumpLHE=False melaEFT=False --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &
+fggRunJobs.py --load sig_jobs_2018_UL.json -d ${outDir}_${year2018Dir} -x cmsRun ../workspaceVbf.py metaDataSrc=flashgg dumpTrees=False doSystematics=True applyNNLOPSweight=True recalculatePDFWeights=True doPdfWeights=True useParentDataset=True anomalousCouplings=True dumpLHE=False melaEFT=True --nCondorCpu=2 pujidWP=tight maxEvents=-1 --stage-to=${storageDir}/${outDir}_${year2018Dir} -q workday -n 100 -H --no-copy-proxy --no-use-tarball &

--- a/Systematics/test/runAnomCouplings/sig_jobs_2016postVFP_UL.json
+++ b/Systematics/test/runAnomCouplings/sig_jobs_2016postVFP_UL.json
@@ -1,76 +1,76 @@
 {
     "cmdLine"  : "metaConditions=$CMSSW_BASE/src/flashgg/MetaData/data/MetaConditions/Era2016_legacyPostVFP_v1.json campaign=Era2016_legacyPostVFP_v1_Summer20UL useAAA=True lumiMask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt puTarget=2.789e-06,1.969e-05,6.75e-05,7.732e-05,0.0001006,0.0001261,0.000143,0.0002099,0.0003984,0.0008259,0.002414,0.005797,0.01087,0.01696,0.02361,0.0304,0.03657,0.04143,0.04496,0.04756,0.04968,0.05155,0.05293,0.05351,0.05321,0.05224,0.05074,0.04876,0.04625,0.04322,0.0397,0.0358,0.03167,0.02744,0.02327,0.01928,0.01559,0.01227,0.009377,0.006939,0.004959,0.003413,0.002259,0.001435,0.0008742,0.0005108,0.0002864,0.0001542,8.001e-05,4.012e-05,1.956e-05,9.352e-06,4.439e-06,2.126e-06,1.049e-06,5.43e-07,2.988e-07,1.748e-07,1.076e-07,6.863e-08,4.469e-08,2.937e-08,1.933e-08,1.268e-08,8.265e-09,5.343e-09,3.422e-09,2.172e-09,1.365e-09,8.493e-10,5.235e-10,3.197e-10,1.934e-10,1.16e-10,6.896e-11,4.065e-11,2.376e-11,1.378e-11,7.93e-12,4.528e-12,2.566e-12,1.443e-12,8.056e-13,4.464e-13,2.456e-13,1.341e-13,7.268e-14,3.91e-14,2.087e-14,1.106e-14,5.816e-15,3.034e-15,1.571e-15,8.065e-16,4.108e-16,2.076e-16,1.04e-16,5.167e-17,2.546e-17",
     "processes": {
-	"ggh"   : [
+	"ggh_125"   : [
             "/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8"
         ],
-	"vbfh"   : [
+	"vbf_125"   : [
             "/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8"
         ],
-        "vbfh_ALT_L1" : [
+        "vbf_ALT_L1_125" : [
             "/VBFHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1f05" : [
+        "vbf_ALT_L1f05_125" : [
             "/VBFHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zg" : [
+        "vbf_ALT_L1Zg_125" : [
             "/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zgf05" : [
+        "vbf_ALT_L1Zgf05_125" : [
             "/VBFHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0M" : [
+        "vbf_ALT_0M_125" : [
             "/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0Mf05" : [        
+        "vbf_ALT_0Mf05_125" : [        
             "/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PH" : [
+        "vbf_ALT_0PH_125" : [
             "/VBFHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PHf05" : [        
+        "vbf_ALT_0PHf05_125" : [        
             "/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PM" : [
+        "vbf_ALT_0PM_125" : [
             "/VBFHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh" : [
+        "zh_125" : [
             "/ZH_HToGG_ZToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "zh_ALT_L1" : [
+        "zh_ALT_L1_125" : [
             "/ZHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1f05" : [        
+        "zh_ALT_L1f05_125" : [        
             "/ZHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zg" : [
+        "zh_ALT_L1Zg_125" : [
             "/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zgf05" : [
+        "zh_ALT_L1Zgf05_125" : [
             "/ZHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0M" : [        
+        "zh_ALT_0M_125" : [        
             "/ZHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0Mf05" : [        
+        "zh_ALT_0Mf05_125" : [        
             "/ZHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PH" : [
+        "zh_ALT_0PH_125" : [
             "/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PHf05" : [
+        "zh_ALT_0PHf05_125" : [
             "/ZHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PM" : [
+        "zh_ALT_0PM_125" : [
             "/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh" : [
+        "wh_125" : [
             "/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8",
@@ -78,29 +78,29 @@
             "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WplusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "wh_ALT_L1f05" : [
+        "wh_ALT_L1f05_125" : [
             "/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PH" : [
+        "wh_ALT_0PH_125" : [
             "/WHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PHf05" : [
+        "wh_ALT_0PHf05_125" : [
             "/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PM" : [
+        "wh_ALT_0PM_125" : [
             "/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth" : [
+        "tth_125" : [
             "/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8"
         ],
-        "tth_ALT_0M" : [
+        "tth_ALT_0M_125" : [
             "/ttHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0Mf05" : [
+        "tth_ALT_0Mf05_125" : [
             "/ttHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0PM" : [
+        "tth_ALT_0PM_125" : [
             "/ttHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ]
     }

--- a/Systematics/test/runAnomCouplings/sig_jobs_2016preVFP_UL.json
+++ b/Systematics/test/runAnomCouplings/sig_jobs_2016preVFP_UL.json
@@ -1,76 +1,76 @@
 {
     "cmdLine"  : "metaConditions=$CMSSW_BASE/src/flashgg/MetaData/data/MetaConditions/Era2016_legacyPreVFP_v1.json campaign=Era2016_legacyPreVFP_v1_Summer20UL useAAA=True lumiMask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt puTarget=4.548e-06,1.601e-05,5.089e-05,0.0001143,0.0002035,0.0003172,0.0004688,0.0006826,0.0009665,0.001345,0.001884,0.002648,0.003691,0.00505,0.006756,0.00884,0.01132,0.01416,0.01729,0.02053,0.02367,0.02651,0.02888,0.03076,0.03222,0.03338,0.03438,0.0353,0.03619,0.03705,0.03787,0.03859,0.03918,0.03956,0.03969,0.0395,0.03893,0.03792,0.03643,0.03445,0.03201,0.02919,0.02608,0.02281,0.01953,0.01636,0.0134,0.01075,0.008451,0.006517,0.004938,0.003683,0.00271,0.001971,0.00142,0.001015,0.0007202,0.000508,0.0003561,0.000248,0.0001714,0.0001175,7.979e-05,5.36e-05,3.56e-05,2.337e-05,1.515e-05,9.699e-06,6.136e-06,3.836e-06,2.371e-06,1.45e-06,8.777e-07,5.259e-07,3.121e-07,1.834e-07,1.067e-07,6.145e-08,3.501e-08,1.973e-08,1.099e-08,6.041e-09,3.278e-09,1.755e-09,9.256e-10,4.811e-10,2.462e-10,1.24e-10,6.147e-11,2.996e-11,1.436e-11,6.767e-12,3.134e-12,1.426e-12,6.376e-13,2.801e-13,1.209e-13,5.13e-14,2.142e-14",
     "processes": {
-	"ggh"   : [
+	"ggh_125"   : [
             "/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8"
         ],
-	"vbfh"   : [
+	"vbf_125"   : [
             "/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8"
         ],
-        "vbfh_ALT_L1" : [
+        "vbf_ALT_L1_125" : [
             "/VBFHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1f05" : [
+        "vbf_ALT_L1f05_125" : [
             "/VBFHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zg" : [
+        "vbf_ALT_L1Zg_125" : [
             "/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zgf05" : [
+        "vbf_ALT_L1Zgf05_125" : [
             "/VBFHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0M" : [
+        "vbf_ALT_0M_125" : [
             "/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0Mf05" : [        
+        "vbf_ALT_0Mf05_125" : [        
             "/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PH" : [
+        "vbf_ALT_0PH_125" : [
             "/VBFHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PHf05" : [        
+        "vbf_ALT_0PHf05_125" : [        
             "/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PM" : [
+        "vbf_ALT_0PM_125" : [
             "/VBFHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh" : [
+        "zh_125" : [
             "/ZH_HToGG_ZToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "zh_ALT_L1" : [
+        "zh_ALT_L1_125" : [
             "/ZHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1f05" : [        
+        "zh_ALT_L1f05_125" : [        
             "/ZHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zg" : [
+        "zh_ALT_L1Zg_125" : [
             "/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zgf05" : [
+        "zh_ALT_L1Zgf05_125" : [
             "/ZHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0M" : [        
+        "zh_ALT_0M_125" : [        
             "/ZHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0Mf05" : [        
+        "zh_ALT_0Mf05_125" : [        
             "/ZHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PH" : [
+        "zh_ALT_0PH_125" : [
             "/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PHf05" : [
+        "zh_ALT_0PHf05_125" : [
             "/ZHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PM" : [
+        "zh_ALT_0PM_125" : [
             "/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh" : [
+        "wh_125" : [
             "/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8",
@@ -78,29 +78,29 @@
             "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WplusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "wh_ALT_L1f05" : [
+        "wh_ALT_L1f05_125" : [
             "/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PH" : [
+        "wh_ALT_0PH_125" : [
             "/WHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PHf05" : [
+        "wh_ALT_0PHf05_125" : [
             "/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PM" : [
+        "wh_ALT_0PM_125" : [
             "/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth" : [
+        "tth_125" : [
             "/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8"
         ],
-        "tth_ALT_0M" : [
+        "tth_ALT_0M_125" : [
             "/ttHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0Mf05" : [
+        "tth_ALT_0Mf05_125" : [
             "/ttHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0PM" : [
+        "tth_ALT_0PM_125" : [
             "/ttHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ]
     }

--- a/Systematics/test/runAnomCouplings/sig_jobs_2017_UL.json
+++ b/Systematics/test/runAnomCouplings/sig_jobs_2017_UL.json
@@ -1,76 +1,76 @@
 {
     "cmdLine"  : "metaConditions=$CMSSW_BASE/src/flashgg/MetaData/data/MetaConditions/Era2017_legacy_v1.json campaign=Era2017_legacy_v1_Summer20UL useAAA=True lumiMask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt puTarget=6.638e-06,2.55e-05,4.835e-05,9.105e-05,9.868e-05,0.0001434,0.0001552,0.0001642,0.0002219,0.000526,0.001054,0.001996,0.003183,0.00458,0.006489,0.009138,0.01271,0.01686,0.02097,0.02478,0.02816,0.03091,0.03303,0.03467,0.03606,0.03736,0.03846,0.03915,0.03927,0.03877,0.03771,0.03621,0.03435,0.03217,0.02979,0.02735,0.02501,0.02283,0.02087,0.01921,0.01793,0.01713,0.01683,0.01702,0.01759,0.01836,0.01907,0.01942,0.01919,0.01823,0.01655,0.01434,0.01184,0.009336,0.007046,0.005109,0.003577,0.002429,0.001608,0.001043,0.0006651,0.0004188,0.0002614,0.0001622,0.0001004,6.222e-05,3.872e-05,2.427e-05,1.536e-05,9.83e-06,6.36e-06,4.159e-06,2.744e-06,1.824e-06,1.218e-06,8.156e-07,5.468e-07,3.663e-07,2.449e-07,1.632e-07,1.083e-07,7.151e-08,4.695e-08,3.063e-08,1.984e-08,1.276e-08,8.142e-09,5.152e-09,3.233e-09,2.01e-09,1.239e-09,7.56e-10,4.57e-10,2.736e-10,1.622e-10,9.52e-11,5.531e-11,3.181e-11,1.81e-11",
     "processes": {
-	"ggh"   : [
+	"ggh_125"   : [
             "/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8"
         ],
-	"vbfh"   : [
+	"vbf_125"   : [
             "/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8"
         ],
-        "vbfh_ALT_L1" : [
+        "vbf_ALT_L1_125" : [
             "/VBFHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1f05" : [
+        "vbf_ALT_L1f05_125" : [
             "/VBFHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zg" : [
+        "vbf_ALT_L1Zg_125" : [
             "/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zgf05" : [
+        "vbf_ALT_L1Zgf05_125" : [
             "/VBFHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0M" : [
+        "vbf_ALT_0M_125" : [
             "/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0Mf05" : [        
+        "vbf_ALT_0Mf05_125" : [        
             "/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PH" : [
+        "vbf_ALT_0PH_125" : [
             "/VBFHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PHf05" : [        
+        "vbf_ALT_0PHf05_125" : [        
             "/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PM" : [
+        "vbf_ALT_0PM_125" : [
             "/VBFHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh" : [
+        "zh_125" : [
             "/ZH_HToGG_ZToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "zh_ALT_L1" : [
+        "zh_ALT_L1_125" : [
             "/ZHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1f05" : [        
+        "zh_ALT_L1f05_125" : [        
             "/ZHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zg" : [
+        "zh_ALT_L1Zg_125" : [
             "/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zgf05" : [
+        "zh_ALT_L1Zgf05_125" : [
             "/ZHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0M" : [        
+        "zh_ALT_0M_125" : [        
             "/ZHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0Mf05" : [        
+        "zh_ALT_0Mf05_125" : [        
             "/ZHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PH" : [
+        "zh_ALT_0PH_125" : [
             "/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PHf05" : [
+        "zh_ALT_0PHf05_125" : [
             "/ZHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PM" : [
+        "zh_ALT_0PM_125" : [
             "/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh" : [
+        "wh_125" : [
             "/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8",
@@ -78,30 +78,30 @@
             "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WplusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "wh_ALT_L1f05" : [
+        "wh_ALT_L1f05_125" : [
             "/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PH" : [
+        "wh_ALT_0PH_125" : [
             "/WHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PHf05" : [
+        "wh_ALT_0PHf05_125" : [
             "/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PM" : [
+        "wh_ALT_0PM_125" : [
             "/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth" : [
+        "tth_125" : [
             "/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8"
         ],
-        "tth_ALT_0M" : [
+        "tth_ALT_0M_125" : [
             "/ttHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0Mf05" : [
+        "tth_ALT_0Mf05_125" : [
             "/ttHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0PM" : [
+        "tth_ALT_0PM_125" : [
             "/ttHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ]
     }

--- a/Systematics/test/runAnomCouplings/sig_jobs_2018_UL.json
+++ b/Systematics/test/runAnomCouplings/sig_jobs_2018_UL.json
@@ -1,76 +1,76 @@
 {
     "cmdLine"  : "metaConditions=$CMSSW_BASE/src/flashgg/MetaData/data/MetaConditions/Era2018_legacy_v1.json campaign=Era2018_legacy_v1_Summer20UL useAAA=True lumiMask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt puTarget=4.233e-06,1.273e-05,4.864e-05,0.0001144,0.0002032,0.0003167,0.0004681,0.0006816,0.000965,0.001343,0.001881,0.002644,0.003685,0.005042,0.006746,0.008827,0.0113,0.01414,0.01726,0.0205,0.02364,0.02648,0.02886,0.03075,0.03222,0.0334,0.03442,0.03536,0.03627,0.03715,0.03797,0.03869,0.03926,0.03962,0.03973,0.03952,0.03892,0.0379,0.03639,0.03441,0.03197,0.02915,0.02604,0.02278,0.0195,0.01633,0.01338,0.01074,0.008438,0.006506,0.00493,0.003677,0.002706,0.001968,0.001418,0.001013,0.0007191,0.0005072,0.0003556,0.0002476,0.0001712,0.0001173,7.967e-05,5.352e-05,3.555e-05,2.333e-05,1.512e-05,9.685e-06,6.127e-06,3.83e-06,2.368e-06,1.448e-06,8.763e-07,5.251e-07,3.116e-07,1.831e-07,1.065e-07,6.136e-08,3.496e-08,1.97e-08,1.097e-08,6.031e-09,3.273e-09,1.752e-09,9.242e-10,4.804e-10,2.458e-10,1.238e-10,6.137e-11,2.992e-11,1.434e-11,6.757e-12,3.129e-12,1.424e-12,6.366e-13,2.797e-13,1.207e-13,5.123e-14,2.139e-14",
     "processes": {
-	"ggh"   : [
+	"ggh_125"   : [
             "/GluGluHToGG_M120_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M125_TuneCP5_13TeV-amcatnloFXFX-pythia8",
             "/GluGluHToGG_M130_TuneCP5_13TeV-amcatnloFXFX-pythia8"
         ],
-	"vbfh"   : [
+	"vbf_125"   : [
             "/VBFHToGG_M120_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M125_TuneCP5_13TeV-amcatnlo-pythia8",
             "/VBFHToGG_M130_TuneCP5_13TeV-amcatnlo-pythia8"
         ],
-        "vbfh_ALT_L1" : [
+        "vbf_ALT_L1_125" : [
             "/VBFHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1f05" : [
+        "vbf_ALT_L1f05_125" : [
             "/VBFHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zg" : [
+        "vbf_ALT_L1Zg_125" : [
             "/VBFHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_L1Zgf05" : [
+        "vbf_ALT_L1Zgf05_125" : [
             "/VBFHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0M" : [
+        "vbf_ALT_0M_125" : [
             "/VBFHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0Mf05" : [        
+        "vbf_ALT_0Mf05_125" : [        
             "/VBFHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PH" : [
+        "vbf_ALT_0PH_125" : [
             "/VBFHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PHf05" : [        
+        "vbf_ALT_0PHf05_125" : [        
             "/VBFHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "vbfh_ALT_0PM" : [
+        "vbf_ALT_0PM_125" : [
             "/VBFHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh" : [
+        "zh_125" : [
             "/ZH_HToGG_ZToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/ZH_HToGG_ZToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "zh_ALT_L1" : [
+        "zh_ALT_L1_125" : [
             "/ZHiggs0L1ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1f05" : [        
+        "zh_ALT_L1f05_125" : [        
             "/ZHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zg" : [
+        "zh_ALT_L1Zg_125" : [
             "/ZHiggs0L1ZgToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_L1Zgf05" : [
+        "zh_ALT_L1Zgf05_125" : [
             "/ZHiggs0L1Zgf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0M" : [        
+        "zh_ALT_0M_125" : [        
             "/ZHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0Mf05" : [        
+        "zh_ALT_0Mf05_125" : [        
             "/ZHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PH" : [
+        "zh_ALT_0PH_125" : [
             "/ZHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PHf05" : [
+        "zh_ALT_0PHf05_125" : [
             "/ZHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "zh_ALT_0PM" : [
+        "zh_ALT_0PM_125" : [
             "/ZHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh" : [
+        "wh_125" : [
             "/WminusH_HToGG_WToAll_M120_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WminusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8",
@@ -78,30 +78,30 @@
             "/WplusH_HToGG_WToAll_M125_TuneCP5_13TeV-powheg-pythia8",
             "/WplusH_HToGG_WToAll_M130_TuneCP5_13TeV-powheg-pythia8"
         ],
-        "wh_ALT_L1f05" : [
+        "wh_ALT_L1f05_125" : [
             "/WHiggs0L1f05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PH" : [
+        "wh_ALT_0PH_125" : [
             "/WHiggs0PHToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PHf05" : [
+        "wh_ALT_0PHf05_125" : [
             "/WHiggs0PHf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "wh_ALT_0PM" : [
+        "wh_ALT_0PM_125" : [
             "/WHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth" : [
+        "tth_125" : [
             "/ttHJetToGG_M120_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M125_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8",
             "/ttHJetToGG_M130_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8"
         ],
-        "tth_ALT_0M" : [
+        "tth_ALT_0M_125" : [
             "/ttHiggs0MToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0Mf05" : [
+        "tth_ALT_0Mf05_125" : [
             "/ttHiggs0Mf05ph0ToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ],
-        "tth_ALT_0PM" : [
+        "tth_ALT_0PM_125" : [
             "/ttHiggs0PMToGG_M125_TuneCP5_13TeV-JHUGenV7011-pythia8"
         ]
     }

--- a/Systematics/test/workspaceVbf.py
+++ b/Systematics/test/workspaceVbf.py
@@ -185,7 +185,7 @@ customize.options.register('dumpTrees',
                            'dumpTrees'
                            )
 customize.options.register('dumpWorkspace',
-                           True,
+                           False,
                            VarParsing.VarParsing.multiplicity.singleton,
                            VarParsing.VarParsing.varType.bool,
                            'dumpWorkspace'
@@ -524,9 +524,10 @@ if is_signal and customize.melaEFT and (customize.processId.count('vbf_') or cus
     #process.lheInfosSeq += process.genParticleSequence
     #process.lheInfosSeq += process.particleLevelSequence
     from flashgg.Taggers.melaWeights_cff import addMelaWeights_ACJHU
-    addMelaWeights_ACJHU(process,mode)
+    addMelaWeights_ACJHU(process,mode,customize.metaConditions['bRegression']['year'])
     process.lheInfosSeq += process.weightsAC
 
+    
     variables_mela = [
         "h0phWeight[1,-999999.,999999.] := tagTruth().melaWeight(\"h0ph\")",
         "h0ph_f05Weight[1,-999999.,999999.] := tagTruth().melaWeight(\"h0ph_f05\")",
@@ -896,5 +897,6 @@ customize(process)
 #    systematicsInputList.append(tag)
 #    self.createJECESource()
 #    self.createJERESource()
+# 3. comment here the line: printSystematicInfo(process)
 
 


### PR DESCRIPTION
* fix the MELA LHE event initialization with year taken from MetaData
* fix the process ID in signal JSONs naming to be compliant with finalfits and with the new workspaceVbf.py
* shell scripts updated to run with MELA weights, PDFs (with recalculation of PDF weights)
